### PR TITLE
Issue 197: Yearly Spend Calculation for Subscriptions

### DIFF
--- a/contributors/Krishna200608/server/src/controllers/subscription.controller.js
+++ b/contributors/Krishna200608/server/src/controllers/subscription.controller.js
@@ -1,6 +1,6 @@
 import { Subscription } from '../models/Subscription.js';
 import { validateCreateSubscription } from '../validators/subscription.validator.js';
-import { calculateMonthlySpend } from '../services/subscriptionMetrics.js';
+import { calculateMonthlySpend, calculateYearlySpend } from '../services/subscriptionMetrics.js';
 
 
 export const createSubscription = async (req, res) => {
@@ -48,11 +48,13 @@ export const getUserSubscriptions = async (req, res) => {
       .select('-__v');
 
     const monthlySpend = calculateMonthlySpend(subscriptions);
+    const yearlySpend = calculateYearlySpend(subscriptions);
 
     return res.status(200).json({
       data: subscriptions,
       meta: {
         monthlySpend,
+        yearlySpend,
       },
     });
   } catch (error) {

--- a/contributors/Krishna200608/server/src/services/subscriptionMetrics.js
+++ b/contributors/Krishna200608/server/src/services/subscriptionMetrics.js
@@ -1,8 +1,37 @@
 import { BILLING_CYCLES, SUBSCRIPTION_STATUS } from '../constants/subscription.constants.js';
 
+// Convert a subscription into its yearly amount
+export const getYearlyAmount = (subscription) => {
+  if (!subscription) return 0;
+
+  const { amount, billingCycle, status } = subscription;
+
+  if (status !== SUBSCRIPTION_STATUS.ACTIVE) return 0;
+  if (typeof amount !== 'number' || isNaN(amount) || amount <= 0) return 0;
+
+  switch (billingCycle) {
+    case BILLING_CYCLES.MONTHLY:
+      return amount * 12;
+
+    case BILLING_CYCLES.YEARLY:
+      return amount;
+
+    default:
+      return 0;
+  }
+};
+
+// Calculate total yearly spend
+export const calculateYearlySpend = (subscriptions = []) => {
+  const total = subscriptions.reduce((sum, sub) => {
+    return sum + getYearlyAmount(sub);
+  }, 0);
+
+  return Math.round(total * 100) / 100;
+};
+
 
 //Convert a subscription into its monthly amount
-
 export const getMonthlyAmount = (subscription) => {
   if (!subscription) return 0;
 


### PR DESCRIPTION
# Issue: #197

> ⚠️ This PR must be linked to a valid OpenCode issue number.
> PRs without an issue number may not be reviewed.

---

Thank you for contributing to **SubSentry** 🚀  
Please complete this template carefully to help mentors and bots review your PR efficiently.

---

## 📌 Description

Extended the subscription metrics logic to compute the **total yearly spend**
across all user subscriptions. The calculation correctly aggregates costs across
different billing cycles and complements the existing monthly spend view, enabling
a clearer understanding of long-term subscription expenses.

---

## 🧩 Issue Reference

**Related Issue:** #197

---

## 🛠️ What Did You Implement?

Please list the **major things you worked on** in this PR:

- [x] API / backend logic

---

## 📁 Workspace Confirmation (MANDATORY)

Since all issues are **Open for All**, confirm the following:

- [x] All changes are inside  
  `contributors/Krishna200608/`
- [x] Base `server/` files were **copied from the main directory**
- [x] No files outside my personal workspace were modified

---

## 🧪 Testing Performed

Please check what applies:

- [x] Backend server runs locally without errors
- [x] APIs tested with valid inputs
- [x] APIs tested with invalid / edge-case inputs
- [x] No console errors or warnings

---

## 📷 Screenshots / Demo (REQUIRED for most PRs)

Please attach **screenshots or recordings** showing:

- Folder structure (updated service layer)
<img width="1244" height="688" alt="image" src="https://github.com/user-attachments/assets/d868aecc-fdf6-4f23-be0b-78dd8f91eb9c" />


- Postman response for `GET /api/subscriptions` displaying:
  - `monthlySpend`
  - `yearlySpend`
 
<img width="1752" height="859" alt="image" src="https://github.com/user-attachments/assets/c6f52633-9f0a-4b6d-abe4-07738a70be45" />

---

## ✅ Final PR Checklist

Before submitting, ensure:

- [x] This PR addresses **only one issue**
- [x] Issue number is mentioned at the top
- [x] Code is readable and well-structured
- [x] No unnecessary files are included
- [x] No sensitive data or `.env` files committed
- [x] Commit messages follow project conventions
- [x] PR title is clear and descriptive

---

## 📎 Additional Notes for Reviewers

Yearly spend calculation reuses shared helper logic to avoid duplicate math.
Only active subscriptions with supported billing cycles (monthly/yearly) are
considered. Currency conversion is intentionally out of scope for this issue.
