### PR TITLE
Yearly Spend Calculation

### DIFF
--- a/contributors/Hac144/server/spendCalculator.js
+++ b/contributors/Hac144/server/spendCalculator.js
@@ -1,0 +1,39 @@
+// Helper functions
+function getYearlyAmount(subscription) {
+  if (subscription.billingCycle === "monthly") {
+    return subscription.amount * 12;
+  }
+  if (subscription.billingCycle === "yearly") {
+    return subscription.amount;
+  }
+  return 0;
+}
+
+function calculateYearlySpend(subscriptions) {
+  return subscriptions.reduce((total, sub) => total + getYearlyAmount(sub), 0);
+}
+
+
+function getSubscriptions(req, res) {
+
+  const subscriptions = [
+    { name: "Spotify", amount: 119, billingCycle: "monthly" },
+    { name: "Prime", amount: 1499, billingCycle: "yearly" }
+  ];
+
+  const monthlySpend = subscriptions.reduce((total, sub) => {
+    return total + (sub.billingCycle === "monthly" ? sub.amount : 0);
+  }, 0);
+
+ 
+  const yearlySpend = calculateYearlySpend(subscriptions);
+  res.json({
+    data: subscriptions,
+    meta: {
+      monthlySpend,
+      yearlySpend
+    }
+  });
+}
+
+module.exports = { getSubscriptions };

--- a/contributors/Hac144/server/test.js
+++ b/contributors/Hac144/server/test.js
@@ -1,0 +1,8 @@
+const { getSubscriptions } = require("./spendCalculator");
+
+
+const res = {
+  json: (output) => console.log(JSON.stringify(output, null, 2))
+};
+
+getSubscriptions(null, res);


### PR DESCRIPTION
Issue:#197
Added yearly spend calculation for subscriptions API.

- Monthly subscriptions are multiplied by 12
- Yearly subscriptions are added as-is
- meta now includes both monthlySpend and yearlySpend
- Example: Spotify (monthly 119) + Prime (yearly 1499) => yearlySpend: 2927
