### PR TITLE
feat: add yearly spend calculation to subscriptions api

### DIFF
--- a/contributors/Siddharthjagtap346/server/src/utils/spendCalculator.js
+++ b/contributors/Siddharthjagtap346/server/src/utils/spendCalculator.js
@@ -1,0 +1,42 @@
+import { BILLING_CYCLES } from '../constants/subscription.constants.js';
+
+/**
+ * Normalize a subscription amount to YEARLY value
+ */
+const toYearlyAmount = (subscription) => {
+  const { amount, billingCycle, status } = subscription;
+
+  if (status !== 'active' || !amount || isNaN(amount)) return 0;
+
+  switch (billingCycle) {
+    case BILLING_CYCLES.MONTHLY:
+      return amount * 12;
+
+    case BILLING_CYCLES.WEEKLY:
+      return amount * 52;
+
+    case BILLING_CYCLES.YEARLY:
+      return amount;
+
+    default:
+      return 0;
+  }
+};
+
+export const calculateYearlySpend = (subscriptions = []) => {
+  return subscriptions.reduce(
+    (total, sub) => total + toYearlyAmount(sub),
+    0
+  );
+};
+
+/**
+ * Calculate total monthly spend
+ * Reuses yearly normalization (NO duplicate math)
+ */
+export const calculateMonthlySpend = (subscriptions = []) => {
+  return subscriptions.reduce(
+    (total, sub) => total + toYearlyAmount(sub) / 12,
+    0
+  );
+};


### PR DESCRIPTION
# Issue: #197  

> ⚠️ This PR must be linked to a valid OpenCode issue number.
> PRs without an issue number may not be reviewed.

---

Thank you for contributing to **SubSentry** 🚀  
This PR adds the yearly spend calculation feature to the subscriptions API.

---

## 📌 Description

Implemented **yearly spend calculation** for subscriptions.  

- Solves the problem of users not knowing their **total yearly spend** across all subscriptions.  
- Extends the **GET /api/subscriptions** API to return `meta.yearlySpend` alongside `meta.monthlySpend`.  
- Backend logic updated in `subscription.controller.js` and `utils/spendCalculator.js`.  

---

## 🧩 Issue Reference

**Related Issue:** #197

> Note: This issue is “Open for All” and is used to track yearly spend feature.  

---

## 🛠️ What Did You Implement?

- [x] Feature implementation ✅  
- [x] API / backend logic ✅  
- [ ] UI changes  
- [ ] Refactor / cleanup  
- [ ] Documentation update  
- [ ] Demo / setup task  

---

## 📁 Workspace Confirmation (MANDATORY)

- [x] All changes are inside `contributors/siddharthjagtap/`  
- [x] Base `server/` files were copied from the main directory  
- [x] No files outside personal workspace were modified  

---

## 🧪 Testing Performed

- [x] Frontend runs locally without errors  
- [x] Backend server runs locally without errors  
- [x] APIs tested with **valid inputs** (Postman)  
- [x] APIs tested with **invalid / edge-case inputs**  
- [x] No console errors or warnings  

---

## 📷 Screenshots / Demo (REQUIRED for most PRs)

**Attach your screenshots here**:

1. **Creating a Subscription (POST /api/subscriptions)**  
   - Show method, URL, request body, headers  and 201 Created response 
- yearly
<img width="1585" height="986" alt="image" src="https://github.com/user-attachments/assets/66f1d9cc-eec1-47d3-bada-9a9ee2902c3e" />

   - Edge cases included: paused subscription & zero-amount subscription
   - pused subscription
<img width="1920" height="1080" alt="Screenshot 2026-01-13 163300" src="https://github.com/user-attachments/assets/85994fd1-de50-4021-afff-31d12c18e254" />

   - zero amount subscription
<img width="1920" height="1080" alt="Screenshot 2026-01-13 163959" src="https://github.com/user-attachments/assets/68fa83d9-3bc7-41a7-9a42-4de78500b4c3" />

2. **Fetching Subscriptions (GET /api/subscriptions)**  
   - Show method, URL, headers and response JSON including `meta.monthlySpend` and `meta.yearlySpend`  
   - Totals reflect only active subscriptions with amount > 0
   - after edge case testing total amount
<img width="1581" height="979" alt="image" src="https://github.com/user-attachments/assets/cd42d5ae-1c3a-44c4-9aec-2d6d4aa881cf" />
<img width="1388" height="947" alt="image" src="https://github.com/user-attachments/assets/f0f95226-be86-47b6-a3cd-9618442dac4d" />
<img width="501" height="202" alt="image" src="https://github.com/user-attachments/assets/8830d07e-40f9-4636-b6e3-def1a54015c1" />

  
---

## ✅ Final PR Checklist

- [x] This PR addresses only one issue  
- [x] Issue number is mentioned at the top (#197 )  
- [x] Code is readable and well-structured  
- [x] No unnecessary files are included  
- [x] No sensitive data or `.env` files committed  
- [x] Commit messages follow project conventions  
- [x] PR title is clear and descriptive  

---

## 📎 Additional Notes for Reviewers

- `calculateMonthlySpend` and `calculateYearlySpend` helper functions are **reusable** for future features.  
- Works for **monthly, weekly, and yearly billing cycles**.  
- Tested with clean DB (one test user) and multiple subscriptions.  

---

Thank you for contributing to **SubSentry** 💙  
Your effort helps make this project better for everyone 🚀
