### PR TITLE
feat : Yearly amount spent calculation in backend

### DIFF
--- a/contributors/dwivediprashant/server/src/controllers/subscriptionController.js
+++ b/contributors/dwivediprashant/server/src/controllers/subscriptionController.js
@@ -1,8 +1,5 @@
 const Subscription = require("../models/subscription");
-const {
-  calculateMonthlySpend,
-  calculateYearlySpend,
-} = require("../services/subscriptionMetrics");
+const { calculateYearlySpend } = require("../services/subscriptionMetrics");
 ///////////-1)--create subscription---///////////
 
 const createSubscription = async (req, res) => {
@@ -60,7 +57,6 @@ const getSubscriptions = async (req, res) => {
   try {
     const subscriptions = await Subscription.find({}).sort({ createdAt: -1 });
 
-    const monthlySpend = calculateMonthlySpend(subscriptions);
     const yearlySpend = calculateYearlySpend(subscriptions);
 
     res.status(200).json({
@@ -69,7 +65,6 @@ const getSubscriptions = async (req, res) => {
       data: subscriptions,
       count: subscriptions.length,
       meta: {
-        monthlySpend,
         yearlySpend,
       },
     });

--- a/contributors/dwivediprashant/server/src/services/subscriptionMetrics.js
+++ b/contributors/dwivediprashant/server/src/services/subscriptionMetrics.js
@@ -18,26 +18,6 @@ const normalizeAmount = (subscription) => {
   return numericAmount;
 };
 
-const getMonthlyAmount = (subscription) => {
-  const numericAmount = normalizeAmount(subscription);
-
-  if (numericAmount === null) {
-    return 0;
-  }
-
-  const normalizedCycle = String(subscription.billingCycle || "").toLowerCase();
-
-  if (normalizedCycle === "yearly") {
-    return numericAmount / 12;
-  }
-
-  if (normalizedCycle === "monthly") {
-    return numericAmount;
-  }
-
-  return 0;
-};
-
 const getYearlyAmount = (subscription) => {
   const numericAmount = normalizeAmount(subscription);
 
@@ -58,19 +38,6 @@ const getYearlyAmount = (subscription) => {
   return 0;
 };
 
-const calculateMonthlySpend = (subscriptions = []) => {
-  if (!Array.isArray(subscriptions) || subscriptions.length === 0) {
-    return 0;
-  }
-
-  const total = subscriptions.reduce(
-    (sum, subscription) => sum + getMonthlyAmount(subscription),
-    0,
-  );
-
-  return Number(total.toFixed(2));
-};
-
 const calculateYearlySpend = (subscriptions = []) => {
   if (!Array.isArray(subscriptions) || subscriptions.length === 0) {
     return 0;
@@ -85,8 +52,6 @@ const calculateYearlySpend = (subscriptions = []) => {
 };
 
 module.exports = {
-  getMonthlyAmount,
   getYearlyAmount,
-  calculateMonthlySpend,
   calculateYearlySpend,
 };


### PR DESCRIPTION
# Issue: #197 

---

## 📎 Important Notes for Reviewers

### <mark>This PR may causes conflicts and these conflicts are intentionally so inform me to solve them. Reason is simple that is if monthly calculation PR gets merged first then on merging this conflicts must arise because code is written by keeping in mind that one PR solves only one issue </mark>


---

## 📌 Description

- Yearly amount spent calculation logic in backend side

---

## 🧩 Issue Reference

**Related Issue:** #197 

---

## 🛠️ What Did You Implement?

Please list the **major things you worked on** in this PR:

- [x] Feature implementation
- [ ] UI changes
- [ ] API / backend logic
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Demo / setup task


---

## 📁 Workspace Confirmation (MANDATORY)

Since all issues are **Open for All**, confirm the following:

- [x] All changes are inside  
  `contributors/<your-github-username>/`
- [ ] Base `client/` and/or `server/` files were **copied from the main directory**
- [x] No files outside my personal workspace were modified

---

## 🧪 Testing Performed

Please check what applies:

- [ ] Frontend runs locally without errors
- [x] Backend server runs locally without errors
- [x] APIs tested with valid inputs
- [ ] APIs tested with invalid / edge-case inputs
- [x] No console errors or warnings

---

## 📷 Screenshots / Demo (REQUIRED for most PRs)

```json
{
    "success": true,
    "message": "Subscriptions retrieved successfully",
    "data": [{
        "_id": "696aaa9adf31cb10468ae0d0",
        "name": "Netflix",
        "amount": 499,
        "billingCycle": "monthly",
        "renewalDate": "2026-02-01T00:00:00.000Z",
        "isTrial": false,
        "source": "manual",
        "category": "entertainment",
        "notes": "",
        "createdAt": "2026-01-16T21:16:10.748Z",
        "updatedAt": "2026-01-16T21:16:10.748Z",
        "__v": 0
    }, {
        "notes": "",
        "_id": "695c52e40e1d26e71f849779",
        "userId": "user_001",
        "name": "Disney+",
        "amount": 7.99,
        "billingCycle": "monthly",
        "renewalDate": "2024-12-18T00:00:00.000Z",
        "isTrial": false,
        "source": "manual",
        "createdAt": "2026-01-06T00:10:12.476Z",
        "updatedAt": "2026-01-06T00:10:12.476Z",
        "__v": 0
    }, {
        "notes": "",
        "_id": "695c52d00e1d26e71f849775",
        "userId": "user_001",
        "name": "OpenAI ChatGPT Plus",
        "amount": 20,
        "billingCycle": "monthly",
        "renewalDate": "2024-12-12T00:00:00.000Z",
        "isTrial": true,
        "source": "email",
        "createdAt": "2026-01-06T00:09:52.271Z",
        "updatedAt": "2026-01-06T00:09:52.271Z",
        "__v": 0
    }, {
        "notes": "",
        "_id": "695c52c50e1d26e71f849773",
        "userId": "user_001",
        "name": "GitHub Pro",
        "amount": 4,
        "billingCycle": "monthly",
        "renewalDate": "2025-01-05T00:00:00.000Z",
        "isTrial": false,
        "source": "manual",
        "createdAt": "2026-01-06T00:09:41.487Z",
        "updatedAt": "2026-01-06T00:09:41.487Z",
        "__v": 0
    }, {
        "notes": "",
        "_id": "695c52b50e1d26e71f849771",
        "userId": "user_001",
        "name": "Adobe Creative Cloud",
        "amount": 52.99,
        "billingCycle": "monthly",
        "renewalDate": "2024-12-20T00:00:00.000Z",
        "isTrial": false,
        "source": "email",
        "createdAt": "2026-01-06T00:09:25.474Z",
        "updatedAt": "2026-01-06T00:09:25.474Z",
        "__v": 0
    }, {
        "notes": "",
        "_id": "695c529a0e1d26e71f84976d",
        "userId": "user_001",
        "name": "Netflix",
        "amount": 15.99,
        "billingCycle": "monthly",
        "renewalDate": "2024-12-15T00:00:00.000Z",
        "isTrial": false,
        "source": "manual",
        "createdAt": "2026-01-06T00:08:58.753Z",
        "updatedAt": "2026-01-06T00:08:58.753Z",
        "__v": 0
    }],
    "count": 6,
    "meta": {
        "yearlySpend": 7199.64
    }
}
```

---

## ✅ Final PR Checklist

Before submitting, ensure:

- [x] This PR addresses **only one issue**
- [x] Issue number is mentioned at the top
- [x] Code is readable and well-structured
- [x] No unnecessary files are included
- [x] No sensitive data or `.env` files committed
- [x] Commit messages follow project conventions
- [x] PR title is clear and descriptive


---

